### PR TITLE
Refactor: refactor 'member' domain & add apis

### DIFF
--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/controller/MemberController.java
@@ -150,10 +150,34 @@ public class MemberController {
         return HttpResponseUtil.ok(memberService.getMemberProfile(memberId));
     }
 
+    @GetMapping("/v1/member/apps")
+    @Operation(summary = "유저 허용가능 앱 조회", description = """
+            ### 기능
+            - 유저가 자신의 허용가능 앱을 조회합니다.
+            - 아래 '유저 허용가능 앱 수정'에서 위 기능을 이용합니다.
+            """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "허용가능 앱 조회 완료",
+                    content = @Content(schema = @Schema(implementation = GetProfileResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "해당 유저를 찾을 수 없습니다."
+            )
+    })
+    public ResponseEntity<CommonResponse<AllowedAppsDto>> getAllowedApps(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        return HttpResponseUtil.ok(memberService.getAllowedApps(memberId));
+    }
+
     @PutMapping("/v1/member/profile")
     @Operation(summary = "유저 프로필 업데이트", description = """
             ### 기능
-            - 특정 유저의 프로필을 업데이트 합니다. 
+            - 특정 유저의 프로필을 업데이트 합니다.
             
             ### 요청
             - `profileImageId`: 장착할 MemberAsset pk(프로필 이미지)
@@ -244,10 +268,31 @@ public class MemberController {
         return HttpResponseUtil.updated(null);
     }
 
-    @PutMapping("/v1/member/alarm")
-    @Operation(summary = "유저 알람 업데이트", description = """
+    @PutMapping("/v1/member/setting")
+    @Operation(summary = "유저 세팅 업데이트", description = """
             ### 기능
-            - 유저 알림 기능을 끄거나 켭니다.
+            - 유저가 세팅(on/off)하는 값들을 반영합니다.
+            """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "세팅 변경 성공"
+            )
+    })
+    public ResponseEntity<CommonResponse<Void>> updateMemberSetting(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody MemberSettingDto request
+    ) {
+        memberService.updateMemberSetting(memberId, request);
+        return HttpResponseUtil.updated(null);
+    }
+
+    @PutMapping("/v1/member/focus")
+    @Operation(summary = "유저 집중 시작(집중 시작)", description = """
+            ### 기능
+            - 유저가 과목에서 공부를 시작합니다.
+            - 집중중인 상태로 만들어줍니다.
             """
     )
     @ApiResponses({
@@ -256,15 +301,15 @@ public class MemberController {
                     description = "알람 on/off 성공"
             )
     })
-    public ResponseEntity<CommonResponse<Void>> updateAlarm(
+    public ResponseEntity<CommonResponse<Void>> startFocus(
             @AuthenticationPrincipal Long memberId
     ) {
-        memberService.updateAlarmSetting(memberId);
+        memberService.startFocus(memberId);
         return HttpResponseUtil.updated(null);
     }
 
     @PutMapping("/v1/member/apps")
-    @Operation(summary = "유저 허용가능앱 업데이트", description = """
+    @Operation(summary = "유저 허용가능 앱 업데이트", description = """
             ### 기능
             - 유저의 집중 시 허용가능한 앱 목록을 클라이언트가 보낸 목록으로 설정합니다.
             - 빈 리스트를 보낼 경우, 모든 허용가능한 앱이 삭제됩니다.
@@ -281,7 +326,7 @@ public class MemberController {
     })
     public ResponseEntity<CommonResponse<Void>> updateAllowedApps(
             @AuthenticationPrincipal Member member,
-            @Valid @RequestBody UpdateAllowedAppsRequest requests
+            @Valid @RequestBody AllowedAppsDto requests
     ) {
         memberService.updateAllowedApps(member, requests);
         return HttpResponseUtil.updated(null);

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/dto/AllowedAppsDto.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/dto/AllowedAppsDto.java
@@ -3,16 +3,18 @@ package com.studioedge.focus_to_levelup_server.domain.member.dto;
 import com.studioedge.focus_to_levelup_server.domain.member.entity.Member;
 import com.studioedge.focus_to_levelup_server.domain.study.entity.AllowedApp;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public record UpdateAllowedAppsRequest(
+@Builder
+public record AllowedAppsDto(
         @Schema(description = "앱 식별자(패키지명/번들ID)", example = "[\"com.google.android.youtube\", \"com.kakao.talk\"]")
         List<String> appIdentifiers
 ) {
-    public static List<AllowedApp> from(Member member, UpdateAllowedAppsRequest request) {
+    public static List<AllowedApp> from(Member member, AllowedAppsDto request) {
         if (request.appIdentifiers() == null) {
             return Collections.emptyList();
         }
@@ -23,5 +25,21 @@ public record UpdateAllowedAppsRequest(
                         .appIdentifier(appId)
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    public static AllowedAppsDto of(List<AllowedApp> allowedApps) {
+        if (allowedApps.isEmpty()) {
+            return AllowedAppsDto.builder()
+                    .appIdentifiers(Collections.emptyList())
+                    .build();
+        }
+
+        List<String> identifiers = allowedApps.stream()
+                .map(AllowedApp::getAppIdentifier)
+                .collect(Collectors.toList());
+
+        return AllowedAppsDto.builder()
+                .appIdentifiers(identifiers)
+                .build();
     }
 }

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/dto/GetProfileResponse.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/dto/GetProfileResponse.java
@@ -26,6 +26,8 @@ public record GetProfileResponse(
         String belonging,
         @Schema(description = "부스트 여부", example = "true")
         Boolean boosted,
+        @Schema(description = "집중 여부", example = "true")
+        Boolean focusOn,
         @Schema(description = "구독 상태", example = "PREMIUM")
         SubscriptionType subscriptionType
 ) {
@@ -40,6 +42,7 @@ public record GetProfileResponse(
                 .profileBorderUrl(memberInfo.getProfileBorder().getAsset().getAssetUrl())
                 .belonging(memberInfo.getBelonging())
                 .boosted(boosted)
+                .focusOn(member.getIsFocusing())
                 .subscriptionType(subscriptionType)
                 .build();
     }

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/dto/MemberSettingDto.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/dto/MemberSettingDto.java
@@ -1,0 +1,31 @@
+package com.studioedge.focus_to_levelup_server.domain.member.dto;
+
+import com.studioedge.focus_to_levelup_server.domain.member.entity.MemberSetting;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record MemberSettingDto(
+        @Schema(description = "알람 여부", example = "true")
+        @NotNull
+        Boolean alarmOn,
+        @Schema(description = "뽀모도로 여부", example = "true")
+        @NotNull
+        Boolean isPomodoro,
+        @Schema(description = "AI플래너 여부", example = "true")
+        @NotNull
+        Boolean isAIPlanner,
+        @Schema(description = "구독권 메세지 여부", example = "true")
+        @NotNull
+        Boolean isSubscriptionMessageBlocked
+) {
+    public static MemberSettingDto of(MemberSetting memberSetting) {
+        return MemberSettingDto.builder()
+                .alarmOn(memberSetting.getAlarmOn())
+                .isPomodoro(memberSetting.getIsPomodoro())
+                .isAIPlanner(memberSetting.getIsAIPlanner())
+                .isSubscriptionMessageBlocked(memberSetting.getIsSubscriptionMessageBlocked())
+                .build();
+    }
+}

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/entity/Member.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/entity/Member.java
@@ -39,11 +39,15 @@ public class Member extends BaseEntity {
 
     @Column(nullable = false)
     @ColumnDefault("1")
-    private int currentLevel = 1;
+    private Integer currentLevel = 1;
 
     @Column(nullable = false)
     @ColumnDefault("0")
-    private int currentExp = 0;
+    private Integer currentExp = 0;
+
+    @Column(nullable = false)
+    @ColumnDefault("false")
+    private Boolean isFocusing = false; // 현재 집중중의 여부
 
     @Column(length = 500)
     private String refreshToken;
@@ -114,6 +118,14 @@ public class Member extends BaseEntity {
     public void updateNickname(String nickname) {
         this.nickname = nickname;
         this.nicknameUpdatedAt = LocalDateTime.now();
+    }
+
+    public void focusOn() {
+        this.isFocusing = true;
+    }
+
+    public void focusOff() {
+        this.isFocusing = false;
     }
 
     public void withdraw() {

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/entity/MemberSetting.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/entity/MemberSetting.java
@@ -1,5 +1,6 @@
 package com.studioedge.focus_to_levelup_server.domain.member.entity;
 
+import com.studioedge.focus_to_levelup_server.domain.member.dto.MemberSettingDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -28,44 +29,43 @@ public class MemberSetting {
 
     @Column(nullable = false)
     @ColumnDefault("true")
-    private boolean alarmOn = true; // 알림기능 여부
+    private Boolean alarmOn = true; // 알림기능 여부
 
     @Column(nullable = false)
     @ColumnDefault("false")
-    private boolean isFocusing = false; // 현재 집중중의 여부
+    private Boolean isRankingCaution = false; // 경고받은 상태인지 여부
 
     @Column(nullable = false)
     @ColumnDefault("false")
-    private boolean isCaution = false; // 경고받은 상태인지 여부
+    private Boolean isPomodoro = false; // 뽀모도로 기능 여부
 
     @Column(nullable = false)
     @ColumnDefault("false")
-    private boolean isPomodoro = false; // 뽀모도로 기능 여부
+    private Boolean isAIPlanner = false; // AI 플래너 여부
 
     @Column(nullable = false)
     @ColumnDefault("false")
-    private boolean isAIPlanner = false; // AI 플래너 여부
-
-    @Column(nullable = false)
-    @ColumnDefault("false")
-    private boolean isSubscriptionMessageBlocked = false; // 구독권 메세지 차단 여부
+    private Boolean isSubscriptionMessageBlocked = false; // 구독권 메세지 차단 여부
 
     @Column(nullable = false)
     @ColumnDefault("true")
-    private boolean isActiveRanking = true; // 랭킹 활성화 여부
+    private Boolean isRankingActive = true; // 랭킹 활성화 여부
 
-    private LocalDateTime reportedAt; // 경고 당한 날짜
+    private LocalDateTime isRankingCautionAt; // 경고 당한 날짜
 
     @Column(nullable = false)
     @ColumnDefault("0")
-    private int deactivatedCount = 0; // 랭킹에서 비활성화 횟수
+    private Integer rankingDeactivatedCount = 0; // 랭킹에서 비활성화 횟수
 
     @Builder
     public MemberSetting(Member member) {
         this.member = member;
     }
 
-    public void updateAlarmSetting() {
-        this.alarmOn = this.isAlarmOn() == true ? false : true;
+    public void updateSetting(MemberSettingDto request) {
+        this.alarmOn = request.alarmOn();
+        this.isPomodoro = request.isPomodoro();
+        this.isAIPlanner = request.isAIPlanner();
+        this.isSubscriptionMessageBlocked = request.isSubscriptionMessageBlocked();
     }
 }

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/service/MemberService.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/service/MemberService.java
@@ -20,7 +20,13 @@ public interface MemberService {
 
     void updateCategory(Member member, UpdateCategoryRequest request);
 
-    void updateAlarmSetting(Long memberId);
+    void updateMemberSetting(Long memberId, MemberSettingDto request);
 
-    void updateAllowedApps(Member member, UpdateAllowedAppsRequest requests);
+    MemberSettingDto getMemberSetting(Long memberId);
+
+    void updateAllowedApps(Member member, AllowedAppsDto requests);
+
+    AllowedAppsDto getAllowedApps(Long memberId);
+
+    void startFocus(Long memberId);
 }

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/service/MemberServiceImpl.java
@@ -151,18 +151,39 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
-    public void updateAlarmSetting(Long memberId) {
+    public void updateMemberSetting(Long memberId, MemberSettingDto request) {
         MemberSetting memberSetting = memberSettingRepository.findByMemberId(memberId)
                 .orElseThrow(InvalidMemberException::new);
-        memberSetting.updateAlarmSetting();
+        memberSetting.updateSetting(request);
+    }
+
+    @Override
+    public MemberSettingDto getMemberSetting(Long memberId) {
+        MemberSetting memberSetting = memberSettingRepository.findByMemberId(memberId)
+                .orElseThrow(InvalidMemberException::new);
+        return MemberSettingDto.of(memberSetting);
     }
 
     @Override
     @Transactional
-    public void updateAllowedApps(Member member, UpdateAllowedAppsRequest requests) {
+    public void updateAllowedApps(Member member, AllowedAppsDto requests) {
         List<AllowedApp> allowedApps = allowedAppRepository.findAllByMember(member);
         allowedAppRepository.deleteAll(allowedApps);
-        allowedAppRepository.saveAll(UpdateAllowedAppsRequest.from(member, requests));
+        allowedAppRepository.saveAll(AllowedAppsDto.from(member, requests));
+    }
+
+    @Override
+    public AllowedAppsDto getAllowedApps(Long memberId) {
+        List<AllowedApp> allowedApps = allowedAppRepository.findAllByMemberId(memberId);
+        return AllowedAppsDto.of(allowedApps);
+    }
+
+    @Override
+    @Transactional
+    public void startFocus(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+        member.focusOn();
     }
 
     // ----------------------------- PRIVATE METHOD ---------------------------------

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/study/dao/AllowedAppRepository.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/study/dao/AllowedAppRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface AllowedAppRepository extends JpaRepository<AllowedApp, Long> {
     List<AllowedApp> findAllByMember(Member member);
+
+    List<AllowedApp> findAllByMemberId(Long memberId);
 }


### PR DESCRIPTION
### Issue
- #15 

### Summary
- #8 PR에서 누락되었던 API(유저 세팅 변경, 허용 앱 조회)를 추가로 구현 혹은 리팩토링 합니다.

### API Endpoints
- GET /v1/member/profile/{id} (유저 프로필 단일 조회 - 응답에 isFocusing 필드 추가)
- GET /v1/member/apps (신규 - 유저 허용 앱 목록 조회)
- PUT /v1/member/setting (신규 - 유저 세팅 4종 업데이트)
- PUT /v1/member/focus (신규 - 유저 집중 상태 변경)

### Review Points
- `isFocusing` 필드 위치 변경 (핵심 리팩토링)
    - AS-IS: MemberSetting.isFocusing
    - TO-BE: Member.isFocusing
    - 이유: getMemberProfile, getGuildMembers 등 유저 정보를 조회하는 여러 API에서 Member와 MemberSetting을 이중 JOIN해야 하는 성능 문제를 발견했습니다. 유저의 '집중 상태'는 매우 자주 조회되는 핵심 상태이므로, Member 엔티티로 이동시켜 조회 성능을 최적화했습니다.

- 유저 집중 상태 변경 API (PUT /v1/member/focus)
    - `isFocusing` 필드를 true (집중 시작) 또는 false (집중 종료)로 변경하는 API를 추가했습니다.
    - 프론트엔드에서 '공부 시작' 버튼을 누를 때 이 API를 호출하여 상태를 true로 변경하고, saveFocus (학습 시간 저장 API)가 호출될 때 서비스 내부적으로 이 상태를 false로 되돌릴 예정입니다.
    - `getMemberProfile()` API 응답 DTO에도 이 `isFocusing` 필드를 추가했습니다.

- 유저 세팅 API 구현 (PUT /v1/member/setting)
    - `alarmOn`, `pomodoroOn`, `aiPlannerOn`, `blockSubscriptionMessage` 4개의 boolean 값을 @RequestBody DTO로 받아 한 번에 업데이트하도록 구현했습니다. 
    - **해당 방식이 좋을지, 아니면 각각의 API를 모두 생성하는게 좋을지 의견 부탁드립니다. 프론트입장에서.**

- MemberSetting 필드명 명확화

- 신고 관련 기능을 추가하려다 규칙이 완벽하게 정해지지 않았고, 백오피스 기능이나 UI는 아예 없으니 향후 고민하기로 생각했습니다.