### PR TITLE
Hotfix: apply reviews

### DIFF
--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/character/dto/request/CharacterPurchaseRequest.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/character/dto/request/CharacterPurchaseRequest.java
@@ -9,9 +9,6 @@ import lombok.Builder;
 @Builder
 public record CharacterPurchaseRequest(
         @NotNull(message = "캐릭터 ID는 필수입니다.")
-        Long characterId,
-
-        @NotNull(message = "훈련 층수는 필수입니다.")
-        Integer floor  // 캐릭터를 배치할 층수
+        Long characterId
 ) {
 }

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/character/exception/CharacterSlotFullException.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/character/exception/CharacterSlotFullException.java
@@ -1,0 +1,6 @@
+package com.studioedge.focus_to_levelup_server.domain.character.exception;
+
+import com.studioedge.focus_to_levelup_server.global.exception.CommonException;
+
+public class CharacterSlotFullException extends CommonException {
+}

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/character/repository/MemberCharacterRepository.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/character/repository/MemberCharacterRepository.java
@@ -40,4 +40,10 @@ public interface MemberCharacterRepository extends JpaRepository<MemberCharacter
     Optional<MemberCharacter> findByMemberIdAndCharacterId(@Param("memberId") Long memberId, @Param("characterId") Long characterId);
 
     Optional<MemberCharacter> findByMemberIdAndIsDefault(Long memberId, Boolean isDefault);
+
+    /**
+     * 특정 유저의 특정 층수에 배치된 캐릭터 개수 조회
+     */
+    @Query("SELECT COUNT(mc) FROM MemberCharacter mc WHERE mc.member.id = :memberId AND mc.floor = :floor")
+    Long countByMemberIdAndFloor(@Param("memberId") Long memberId, @Param("floor") Integer floor);
 }

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/character/service/CharacterPurchaseService.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/character/service/CharacterPurchaseService.java
@@ -6,6 +6,7 @@ import com.studioedge.focus_to_levelup_server.domain.character.entity.Character;
 import com.studioedge.focus_to_levelup_server.domain.character.entity.MemberCharacter;
 import com.studioedge.focus_to_levelup_server.domain.character.exception.CharacterAlreadyPurchasedException;
 import com.studioedge.focus_to_levelup_server.domain.character.exception.CharacterNotFoundException;
+import com.studioedge.focus_to_levelup_server.domain.character.exception.CharacterSlotFullException;
 import com.studioedge.focus_to_levelup_server.domain.character.repository.CharacterRepository;
 import com.studioedge.focus_to_levelup_server.domain.character.repository.MemberCharacterRepository;
 import com.studioedge.focus_to_levelup_server.domain.member.dao.MemberInfoRepository;
@@ -31,7 +32,8 @@ public class CharacterPurchaseService {
      * 캐릭터 구매
      * 1. 중복 구매 체크
      * 2. 다이아 차감
-     * 3. MemberCharacter 생성
+     * 3. 자동 층수 배치
+     * 4. MemberCharacter 생성
      */
     public MemberCharacterResponse purchaseCharacter(Long memberId, CharacterPurchaseRequest request) {
         // 1. 중복 구매 체크
@@ -52,15 +54,41 @@ public class CharacterPurchaseService {
         // 4. 다이아 차감 (내부에서 검증)
         memberInfo.decreaseDiamond(character.getPrice());
 
-        // 5. MemberCharacter 생성
+        // 5. 자동 층수 배치 (2층 → 3층 → 1층 순서, 각 층 최대 2개)
+        Integer floor = assignFloor(memberId);
+
+        // 6. MemberCharacter 생성
         MemberCharacter memberCharacter = MemberCharacter.builder()
                 .member(member)
                 .character(character)
-                .floor(request.floor())
+                .floor(floor)
                 .build();
 
         memberCharacterRepository.save(memberCharacter);
 
         return MemberCharacterResponse.from(memberCharacter);
+    }
+
+    /**
+     * 캐릭터를 배치할 층수를 자동으로 결정
+     * 우선순위: 2층 → 3층 → 1층
+     * 각 층당 최대 2개까지 배치 가능
+     * 모든 층이 가득 차면 예외 발생
+     */
+    private Integer assignFloor(Long memberId) {
+        // 2층 확인
+        if (memberCharacterRepository.countByMemberIdAndFloor(memberId, 2) < 2) {
+            return 2;
+        }
+        // 3층 확인
+        if (memberCharacterRepository.countByMemberIdAndFloor(memberId, 3) < 2) {
+            return 3;
+        }
+        // 1층 확인
+        if (memberCharacterRepository.countByMemberIdAndFloor(memberId, 1) < 2) {
+            return 1;
+        }
+        // 모든 층이 가득 참
+        throw new CharacterSlotFullException();
     }
 }

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/controller/MemberController.java
@@ -164,7 +164,7 @@ public class MemberController {
             @ApiResponse(
                     responseCode = "200",
                     description = "세팅상태 조회 완료",
-                    content = @Content(schema = @Schema(implementation = GetProfileResponse.class))
+                    content = @Content(schema = @Schema(implementation = MemberSettingDto.class))
             ),
             @ApiResponse(
                     responseCode = "404",
@@ -289,6 +289,24 @@ public class MemberController {
     ) {
         memberService.updateMemberSetting(member, request);
         return HttpResponseUtil.updated(null);
+    }
+
+    @GetMapping("/v1/member/currency")
+    @Operation(summary = "유저 재화 조회", description = """
+            ### 기능
+            - 유저의 현재 재화(레벨, 골드, 다이아몬드)를 조회합니다.
+            """)
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "재화 조회 성공",
+                    content = @Content(schema = @Schema(implementation = MemberCurrencyResponse.class))
+            )
+    })
+    public ResponseEntity<CommonResponse<MemberCurrencyResponse>> getMemberCurrency(
+            @AuthenticationPrincipal Member member
+    ) {
+        return HttpResponseUtil.ok(memberService.getMemberCurrency(member));
     }
 
     // ============= 테스트용 API =============

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/dto/MemberCurrencyResponse.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/dto/MemberCurrencyResponse.java
@@ -1,0 +1,17 @@
+package com.studioedge.focus_to_levelup_server.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record MemberCurrencyResponse(
+        @Schema(description = "레벨", example = "5")
+        Integer level,
+
+        @Schema(description = "골드", example = "1000")
+        Integer gold,
+
+        @Schema(description = "다이아몬드", example = "50")
+        Integer diamond
+) {
+}

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/dto/MemberSettingDto.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/dto/MemberSettingDto.java
@@ -18,7 +18,10 @@ public record MemberSettingDto(
         Boolean isAIPlanner,
         @Schema(description = "구독권 메세지 여부", example = "true")
         @NotNull
-        Boolean isSubscriptionMessageBlocked
+        Boolean isSubscriptionMessageBlocked,
+        @Schema(description = "총 누적 통계 색상 (Hex 코드, # 제외)", example = "FFFF00")
+        @NotNull
+        String totalStatColor
 ) {
     public static MemberSettingDto of(MemberSetting memberSetting) {
         return MemberSettingDto.builder()
@@ -26,6 +29,7 @@ public record MemberSettingDto(
                 .isPomodoro(memberSetting.getIsPomodoro())
                 .isAIPlanner(memberSetting.getIsAIPlanner())
                 .isSubscriptionMessageBlocked(memberSetting.getIsSubscriptionMessageBlocked())
+                .totalStatColor(memberSetting.getTotalStatColor())
                 .build();
     }
 }

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/entity/MemberSetting.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/entity/MemberSetting.java
@@ -70,6 +70,7 @@ public class MemberSetting {
         this.isPomodoro = request.isPomodoro();
         this.isAIPlanner = request.isAIPlanner();
         this.isSubscriptionMessageBlocked = request.isSubscriptionMessageBlocked();
+        this.totalStatColor = request.totalStatColor();
     }
 
     public void updateTotalStatColor(String color) {

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/service/MemberService.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/service/MemberService.java
@@ -23,6 +23,9 @@ public interface MemberService {
     void updateMemberSetting(Member member, MemberSettingDto request);
 
     MemberSettingDto getMemberSetting(Member member);
+
+    MemberCurrencyResponse getMemberCurrency(Member member);
+
     // 테스트용
     void updateCurrency(Long memberId, Integer gold, Integer diamond);
 

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/service/MemberServiceImpl.java
@@ -251,6 +251,19 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public MemberCurrencyResponse getMemberCurrency(Member member) {
+        MemberInfo memberInfo = memberInfoRepository.findByMemberId(member.getId())
+                .orElseThrow(InvalidMemberException::new);
+
+        return MemberCurrencyResponse.builder()
+                .level(member.getLevel())
+                .gold(memberInfo.getGold())
+                .diamond(memberInfo.getDiamond())
+                .build();
+    }
+
+    @Override
     @Transactional
     public void updateCurrency(Long memberId, Integer gold, Integer diamond) {
         MemberInfo memberInfo = memberInfoRepository.findByMemberId(memberId)

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/stat/service/DailyStatService.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/stat/service/DailyStatService.java
@@ -4,7 +4,6 @@ import com.studioedge.focus_to_levelup_server.domain.focus.dao.DailyGoalReposito
 import com.studioedge.focus_to_levelup_server.domain.focus.entity.DailyGoal;
 import com.studioedge.focus_to_levelup_server.domain.stat.dto.DailyStatListResponse;
 import com.studioedge.focus_to_levelup_server.domain.stat.dto.DailyStatResponse;
-import com.studioedge.focus_to_levelup_server.domain.stat.exception.StatMonthNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,10 +31,6 @@ public class DailyStatService {
         // 1. DB에서 해당 월의 DailyGoal 데이터를 한 번에 조회
         List<DailyGoal> goals = dailyGoalRepository.
                 findAllByMemberIdAndDailyGoalDateBetween(memberId, startDate, endDate);
-
-        if (goals.isEmpty()) {
-            throw new StatMonthNotFoundException();
-        }
 
         // 'goals' 리스트에서 총 집중 시간을 미리 계산합니다.
         int totalFocusMinutes = goals.stream()

--- a/src/main/java/com/studioedge/focus_to_levelup_server/global/exception/ExceptionMapper.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/global/exception/ExceptionMapper.java
@@ -111,6 +111,8 @@ public class ExceptionMapper {
                 ExceptionSituation.of("유효하지 않은 진화 단계입니다. 보유한 진화 단계만 선택할 수 있습니다.", HttpStatus.BAD_REQUEST));
         mapper.put(MemberCharacterNotFoundException.class,
                 ExceptionSituation.of("보유하지 않은 캐릭터입니다.", HttpStatus.NOT_FOUND));
+        mapper.put(CharacterSlotFullException.class,
+                ExceptionSituation.of("훈련장 슬롯이 가득 찼습니다. 캐릭터를 배치할 수 없습니다.", HttpStatus.BAD_REQUEST));
     }
 
     /**


### PR DESCRIPTION
# 피드백 반영 사항

## 1. 통계 색상 관리 개선
- `MemberSettingDto`에 `totalStatColor` 필드 추가
- `member/settings` API에서 통계 색상 포함하여 반환/업데이트
- Swagger 응답 스키마 수정

## 2. 일간 통계 빈 리스트 반환
- `stats/daily` API에서 데이터 없을 시 404 대신 빈 리스트 반환
- 다른 통계 API들과 동작 통일

## 3. 캐릭터 자동 배치 시스템
- `characters/purchase`에서 `floor` 파라미터 제거
- 2층 → 3층 → 1층 순서로 자동 배치 (각 층 최대 2개)
- 슬롯 가득 찰 시 예외 발생

## 4. 재화 조회 API 추가
- `GET /api/v1/member/currency` 엔드포인트 추가
- level, gold, diamond 정보 반환