### PR TITLE
Hotfitx: apply review

### DIFF
--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/member/controller/MemberController.java
@@ -124,14 +124,18 @@ public class MemberController {
         return HttpResponseUtil.ok(memberService.getMemberAsset(member, PageRequest.of(page, size)));
     }
 
-    @GetMapping("/v1/member/profile/{id}")
+    @GetMapping("/v1/member/profile")
     @Operation(summary = "유저 프로필 단일 조회", description = """
             ### 기능
             - 특정 `memberId`를 가진 유저의 프로필을 조회합니다.
-            
+
             ### 요청
-            - `id`: 조회할 유저의 pk. (쿼리파라미터) ('유저 리스트 조회'에서 주어진 pk를 활용합니다.)
-                - 만약 `id`==null 이라면, 이는 자신을 조회하는 요청으로 간주하여 자신의 정볼르 조회합니다.
+            - `id`: 조회할 유저의 pk. (경로 변수) ('유저 리스트 조회'에서 주어진 pk를 활용합니다.)
+                - 만약 `id`가 없다면, 이는 자신을 조회하는 요청으로 간주하여 자신의 정보를 조회합니다.
+
+            ### 예시
+            - GET /v1/member/profile → 자기 자신 프로필 조회
+            - GET /v1/member/profile/123 → 123번 유저 프로필 조회
             """
     )
     @ApiResponses({

--- a/src/main/java/com/studioedge/focus_to_levelup_server/domain/ranking/entity/RankingResult.java
+++ b/src/main/java/com/studioedge/focus_to_levelup_server/domain/ranking/entity/RankingResult.java
@@ -33,7 +33,7 @@ public class RankingResult extends BaseEntity {
     @Column(nullable = false)
     private Tier tier;
 
-    @Column(nullable = false)
+    @Column(name = "user_rank", nullable = false)
     private Integer rank;
 
     @Column(nullable = false)


### PR DESCRIPTION
# PR 변경사항

## 🐛 Bug Fix: 프로필 조회 API 파라미터 수정

### 문제점
- `/api/v1/member/profile` 경로로 자기 자신 프로필 조회 시 404 에러 발생
- `@PathVariable`과 `@RequestParam` 혼용으로 인한 파라미터 처리 오류

### 해결
- `@PathVariable` → `@RequestParam(required = false)`으로 통일
- 파라미터 없을 시 자동으로 본인 ID 사용

### API 사용법
```bash
# 자기 자신 프로필 조회
GET /api/v1/member/profile

# 특정 유저 프로필 조회
GET /api/v1/member/profile?id=123
```

---

## 🔧 기타 수정

### RankingResult.java
- MySQL 예약어 충돌 해결: `rank` 컬럼 → `user_rank`